### PR TITLE
feat: add register form

### DIFF
--- a/front-end/src/components/register-form/RegisterForm.tsx
+++ b/front-end/src/components/register-form/RegisterForm.tsx
@@ -1,0 +1,87 @@
+import { useAppForm } from '@/hooks/form'
+import z from 'zod'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '../ui/card'
+import { FieldGroup } from '../ui/field'
+
+const registerSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Name is required')
+    .max(50, "Name can't exceed 50 characters"),
+  email: z.email('Please provide a valid email address'),
+})
+
+type RegisterFormValues = z.infer<typeof registerSchema>
+
+export default function RegisterForm({
+  onSubmit,
+  linkProvider: LinkProvider,
+}: {
+  onSubmit: (value: RegisterFormValues) => void
+  linkProvider: React.ComponentType<{ children: React.ReactNode }>
+}) {
+  const form = useAppForm({
+    defaultValues: {
+      name: '',
+      email: '',
+    },
+    validators: {
+      onSubmit: registerSchema,
+    },
+    onSubmit: ({ value }) => {
+      onSubmit(value)
+    },
+  })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Register</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form
+          id="register-form"
+          onSubmit={(e) => {
+            e.preventDefault()
+            form.handleSubmit()
+          }}
+        >
+          <FieldGroup>
+            <form.AppField
+              name="name"
+              children={(field) => <field.TextField placeholder="Name" />}
+            />
+            <form.AppField
+              name="email"
+              children={(field) => (
+                <field.TextField placeholder="Email address" />
+              )}
+            />
+          </FieldGroup>
+        </form>
+      </CardContent>
+      <CardFooter className="flex flex-col gap-4">
+        <form.AppForm>
+          <form.FormButton
+            enabledText="Create Account"
+            loadingText="Creating Account"
+            disabledText="Enter your details to register"
+            formId="register-form"
+          />
+        </form.AppForm>
+        <div className="text-muted-foreground text-center text-sm">
+          Already have an account?{' '}
+          <LinkProvider>
+            <span className="text-primary">Log in</span>
+          </LinkProvider>
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/front-end/src/components/register-form/__tests__/RegisterForm.stories.tsx
+++ b/front-end/src/components/register-form/__tests__/RegisterForm.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import RegisterForm from '../RegisterForm'
+
+const meta = {
+  title: 'Register',
+  component: RegisterForm,
+} satisfies Meta<typeof RegisterForm>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    linkProvider: ({ children }: { children: React.ReactNode }) => (
+      <a href="/">{children}</a>
+    ),
+    onSubmit: (val) => console.log(val),
+  },
+}

--- a/front-end/src/components/register-form/__tests__/RegisterForm.test.tsx
+++ b/front-end/src/components/register-form/__tests__/RegisterForm.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import RegisterForm from '../RegisterForm'
+import setupUserEvent from '@/lib/utils/testing/setupUserEvent'
+
+const MockLinkProvider = ({ children }: { children: React.ReactNode }) => (
+  <a href="/">{children}</a>
+)
+
+describe('RegisterForm', () => {
+  it('should render header text', () => {
+    render(<RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />)
+    expect(screen.getByText(/Register/i)).toBeInTheDocument()
+  })
+  it('should render name field placeholder text', () => {
+    render(<RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />)
+    expect(screen.getByPlaceholderText(/Name/i)).toBeInTheDocument()
+  })
+  it('should render email field placeholder text', () => {
+    render(<RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />)
+    expect(screen.getByPlaceholderText(/Email address/i)).toBeInTheDocument()
+  })
+  it('should render a button', () => {
+    render(<RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+  it('should render login link text', () => {
+    render(<RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />)
+    expect(screen.getByText(/Already have an account\?/i)).toBeInTheDocument()
+    expect(screen.getByText(/Log in/i)).toBeInTheDocument()
+  })
+  it('should show all validation errors when button is pressed with no inputs entered', async () => {
+    const { user } = setupUserEvent(
+      <RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />,
+    )
+    const submitButton = screen.getByRole('button')
+    await user.click(submitButton)
+    await waitFor(() => {
+      expect(screen.getByText('Name is required')).toBeInTheDocument()
+      expect(
+        screen.getByText('Please provide a valid email address'),
+      ).toBeInTheDocument()
+    })
+  })
+  it('should show email validation error for invalid email format', async () => {
+    const { user } = setupUserEvent(
+      <RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />,
+    )
+    await user.type(screen.getByPlaceholderText('Name'), 'John Doe')
+    await user.type(screen.getByPlaceholderText('Email address'), 'notanemail')
+    await user.click(screen.getByRole('button'))
+    expect(
+      screen.getByText('Please provide a valid email address'),
+    ).toBeInTheDocument()
+  })
+  it('should show name length error for names exceeding 50 characters', async () => {
+    const longName = 'a'.repeat(51)
+    const { user } = setupUserEvent(
+      <RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />,
+    )
+    await user.type(screen.getByPlaceholderText('Name'), longName)
+    await user.type(
+      screen.getByPlaceholderText('Email address'),
+      'john@example.com',
+    )
+    await user.click(screen.getByRole('button'))
+    expect(
+      screen.getByText("Name can't exceed 50 characters"),
+    ).toBeInTheDocument()
+  })
+  it('should allow typing in name field', async () => {
+    const { user } = setupUserEvent(
+      <RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />,
+    )
+    const nameField = screen.getByPlaceholderText('Name')
+    await user.type(nameField, 'John Doe')
+    expect(nameField).toHaveValue('John Doe')
+  })
+  it('should allow typing in email field', async () => {
+    const { user } = setupUserEvent(
+      <RegisterForm onSubmit={vi.fn()} linkProvider={MockLinkProvider} />,
+    )
+    const emailField = screen.getByPlaceholderText('Email address')
+    await user.type(emailField, 'john@example.com')
+    expect(emailField).toHaveValue('john@example.com')
+  })
+  it('should call a function on submit', async () => {
+    const mockFunction = vi.fn()
+    const { user } = setupUserEvent(
+      <RegisterForm onSubmit={mockFunction} linkProvider={MockLinkProvider} />,
+    )
+    await user.type(screen.getByPlaceholderText('Name'), 'John Doe')
+    await user.type(
+      screen.getByPlaceholderText('Email address'),
+      'john@example.com',
+    )
+    await user.click(screen.getByRole('button'))
+    expect(mockFunction).toHaveBeenCalled()
+  })
+  it('should call a function on submit with correct values', async () => {
+    const mockFunction = vi.fn()
+    const { user } = setupUserEvent(
+      <RegisterForm onSubmit={mockFunction} linkProvider={MockLinkProvider} />,
+    )
+    await user.type(screen.getByPlaceholderText('Name'), 'John Doe')
+    await user.type(
+      screen.getByPlaceholderText('Email address'),
+      'john@example.com',
+    )
+    await user.click(screen.getByRole('button'))
+    expect(mockFunction).toHaveBeenCalledWith({
+      name: 'John Doe',
+      email: 'john@example.com',
+    })
+  })
+  it('should not call onSubmit when validation fails', async () => {
+    const mockFunction = vi.fn()
+    const { user } = setupUserEvent(
+      <RegisterForm onSubmit={mockFunction} linkProvider={MockLinkProvider} />,
+    )
+    await user.click(screen.getByRole('button'))
+    expect(mockFunction).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Adds a register form that takes a name and email.

To test:
-  `pnpm run storybook`
-  Open "Register" component
-  Enter name and email 
-  Press "Create Account" button

Also run `pnpm run test:watch` and see the rendering, validation and submission tests for the component.